### PR TITLE
fix: Add PresentationCore assembly for Windows sound playback

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ function playSound(filePath: string) {
   } else if (platform === "linux") {
     cmd = `mpg123 -q "${filePath}" 2>/dev/null || aplay "${filePath}"`;
   } else if (platform === "win32") {
-    cmd = `powershell -c "$p = New-Object System.Windows.Media.MediaPlayer; $p.Open('${filePath}'); $p.Play(); Start-Sleep 3"`;
+    cmd = `powershell -c "Add-Type -AssemblyName PresentationCore; $p = New-Object System.Windows.Media.MediaPlayer; $p.Open('${filePath}'); $p.Play(); Start-Sleep 3"`;
   } else {
     return;
   }


### PR DESCRIPTION
Fixes #6  

 ## Summary
  - Fixed Windows sound playback by adding the required `PresentationCore` assembly import

  ## Problem
  The `System.Windows.Media.MediaPlayer` class requires the `PresentationCore` assembly to be loaded. Without it,
  PowerShell throws:
  Cannot find type [System.Windows.Media.MediaPlayer]: verify that the assembly containing this type is loaded.

  ## Solution
  Added `Add-Type -AssemblyName PresentationCore;` before creating the MediaPlayer object in the Windows sound playback   
  command.

  ## Testing
  Tested and confirmed working on Windows.